### PR TITLE
Clear barcode in DeleteAllButOne.

### DIFF
--- a/HitachiModbus_DLL/Modbus/Modbus.cs
+++ b/HitachiModbus_DLL/Modbus/Modbus.cs
@@ -652,6 +652,7 @@ namespace Modbus_DLL {
          LogIt(" \n// Set the format to the smallest size\n ");
          SetAttribute(ccIDX.Start_Stop_Management_Flag, 1);
          SetAttribute(ccPF.Dot_Matrix, 0, "5x8");
+         SetAttribute(ccPF.Barcode_Type, 0, 0);
          SetAttribute(ccIDX.Start_Stop_Management_Flag, 2);
       }
 


### PR DESCRIPTION
Message fails if old message had a bar-code as item 1.